### PR TITLE
Use already-present AWS CLI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -37,12 +37,10 @@ jobs:
       #  artifact sharing, we upload and download from an s3 bucket dedicated
       #  to this purpose.
     - name: Upload artifacts (S3)
-      uses: actions/aws/cli@master
       # Only run for merges to master.
       if: github.ref == 'refs/heads/master'
-      with:
-        args: "s3 cp dist.zip s3://${{ secrets.pkg_aws_bucket_name }}/artifact/${{ github.sha }}"
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.pkg_aws_access_key_id }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.pkg_aws_secret_access_key }}
         AWS_DEFAULT_REGION: ${{ secrets.pkg_aws_region }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.pkg_aws_secret_access_key }}
+      run: "s3 cp dist.zip s3://${{ secrets.pkg_aws_bucket_name }}/artifact/${{ github.sha }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download artifacts (S3)
-      uses: actions/aws/cli@master
-      with:
-        args: "s3 cp s3://${{ secrets.pkg_aws_bucket_name }}/artifact/${{ github.sha }} dist.zip"
+      run: "s3 cp s3://${{ secrets.pkg_aws_bucket_name }}/artifact/${{ github.sha }} dist.zip"
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.pkg_aws_access_key_id }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.pkg_aws_secret_access_key }}
         AWS_DEFAULT_REGION: ${{ secrets.pkg_aws_region }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.pkg_aws_secret_access_key }}
     - name: Unzip distributions
       run: unzip dist.zip
     - uses: pypa/gh-action-pypi-publish@master

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open(readme_path, encoding="utf-8") as f:
 
 setup(
     name="hlp",
-    version="0.2.1",
+    version="0.2.2.dev0",
     author="Chris Hunt",
     author_email="chrahunt@gmail.com",
     classifiers=[


### PR DESCRIPTION
As suggested by GitHub support, the ubuntu environment already has AWS CLI, so no need to use `actions/aws`.